### PR TITLE
Fixes HTML elements not showing cookie data on initial page load

### DIFF
--- a/script.js
+++ b/script.js
@@ -43,3 +43,5 @@ function printValues(_printData)
         document.getElementById("formFilled").style.visibility = "hidden";
     }
 }
+
+document.addEventListener('DOMContentLoaded', setValues);


### PR DESCRIPTION
Added event listener to set the values of the elements when the page loads for the first time. (Equivalent to jQuery's `$('document').ready()` function.)